### PR TITLE
Updated Makefile ARCH param to mach newer versions of libftd2xx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ sixty4 := $(findstring 64-bit, $(shell file $(WINEDLLPATH)/version.dll.so))
 
 ifeq (,$(ARCH))
 ifneq (,$(sixty4))
-ARCH = x64
+ARCH = x86_64
 else
 ARCH = i386
 endif


### PR DESCRIPTION
Newer versions of libftd2 (libftd2xx1.1.12 in my case) updated the arch folder from x64 to `x86_64` so the build will fail with a `file not found` error. Updating the ARCH param in Makefile to the new directory name solves the problem.