### PR TITLE
Add FT_GetDriverVersion() and FT_GetLibraryVersion() and modify Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,14 @@ ARCHIVE = $(LIBFTD)/build/$(ARCH)/libftd2xx.a
 $(info Link with $(ARCHIVE))
 
 ifeq (i386,$(ARCH))
-CFLAGS += -m32
+MACHINE = -m32
 endif
+
+ifeq (x86_64,$(ARCH))
+MACHINE = -m64
+endif
+
+CFLAGS += $(MACHINE)
 
 all: libftd2xx.def ftd2xx.dll.so
 
@@ -61,7 +67,7 @@ ftd2xx.dll.so: ftd2xx.o ftd2xx.spec libxftd2xx.a
           -o ftd2xx.dll ftd2xx.o libxftd2xx.a -shared ftd2xx.spec $(LIBS)
 
 libftd2xx.def: ftd2xx.spec ftd2xx.dll.so
-	winebuild -w --def -o $@ --export ftd2xx.spec
+	winebuild $(MACHINE) -w --def -o $@ --export ftd2xx.spec
 
 install:        ftd2xx.dll.so libftd2xx.def
 	cp ftd2xx.dll.so libftd2xx.def  $(WINEDLLPATH)

--- a/ftd2xx.c
+++ b/ftd2xx.c
@@ -540,3 +540,14 @@ Trace("\n");
   return xFT_SetChars(ftHandle, uEventCh, uEventChEn, uErrorCh, uErrorChEn);
 }
 
+FT_STATUS FT_GetDriverVersion (FT_HANDLE ftHandle, LPDWORD lpdwDriverVersion)
+{
+Trace("\n");
+  return xFT_GetDriverVersion(ftHandle, lpdwDriverVersion);
+}
+
+FT_STATUS WINAPI FT_GetLibraryVersion (LPDWORD lpdwDLLVersion)
+{
+Trace("\n");
+  return xFT_GetLibraryVersion (lpdwDLLVersion);
+}

--- a/ftd2xx.spec
+++ b/ftd2xx.spec
@@ -71,8 +71,8 @@
 71 stdcall FT_GetDeviceInfoList(ptr ptr)
 72 stdcall FT_GetDeviceInfoDetail(long ptr ptr ptr ptr ptr ptr ptr)
 73 stub FT_SetDeadmanTimeout
-74 stub FT_GetDriverVersion
-75 stub FT_GetLibraryVersion
+74 stdcall FT_GetDriverVersion(long ptr)
+75 stdcall FT_GetLibraryVersion(ptr)
 76 stub FT_W32_GetCommMask
 77 stub FT_Rescan
 78 stub FT_Reload


### PR DESCRIPTION
This PR adds two functions that I needed to run some software.
To build the 32 bit version on a 64 bit host I had to change the Makefile, the main problem was that winebuild would try to create 64-bit code even if CFLAGS containe -m32.