### PR TITLE
Stopped CFLAGS overwriting environmental CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #Makefile for wineftd2xx<->ftd2xx shim dll
 #WARNING:  omitting frame pointer causes crashes
-CFLAGS = -g -O0 -Wall
+CFLAGS += -g -O0 -Wall
 LIBS=libxftd2xx.a -ldl -lrt -lpthread
 
 RELEASE=wineftd2xx1.1.1


### PR DESCRIPTION
This PR fixes the issue if a user provides additional compiler options via CFLAGS on the command line, they are not included in the Makefile.